### PR TITLE
test: add test dependencies to trigger risk analyzer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ openai
 langchain-core
 langchain-openai
 langgraph
+requests==2.31.0
+old-unmaintained-lib==0.1.0
+cryptography==3.0.0


### PR DESCRIPTION
## Summary

Added specific test dependencies to trigger the risk analyzer for evaluation purposes.

## Type of Change

🔧 Chore

## Changes Made

- Updated `requirements.txt` to include `requests==2.31.0`, `old-unmaintained-lib==0.1.0`, and `cryptography==3.0.0`.

## How to Test

1. Install the updated dependencies by running `pip install -r requirements.txt`.
2. Verify that all dependencies are installed without errors.
3. Run the risk analyzer to ensure it detects the newly added dependencies.

## Related Issues

_None identified_

---
_Description generated by the AI DevOps Team agent. Feel free to edit._