### PR TITLE
test: add test dependencies to trigger risk analyzer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ openai
 langchain-core
 langchain-openai
 langgraph
+requests==2.31.0
+old-unmaintained-lib==0.1.0
+cryptography==3.0.0


### PR DESCRIPTION
## Summary

Added specific test dependencies to trigger the risk analyzer for dependency evaluation.

## Type of Change

 Chore

## Changes Made

- Updated `requirements.txt` to include `requests==2.31.0`, `old-unmaintained-lib==0.1.0`, and `cryptography==3.0.0`.

## How to Test

1. Run the dependency installation using `pip install -r requirements.txt`.
2. Verify that all dependencies are installed successfully without errors.
3. Ensure the risk analyzer tool is triggered and evaluates the added dependencies.

## Related Issues

_None identified_

---
_Description generated by the AI DevOps Team agent. Feel free to edit._